### PR TITLE
Add media control for small screens

### DIFF
--- a/src/BlazorApp/Components/Portfolio.razor
+++ b/src/BlazorApp/Components/Portfolio.razor
@@ -1,13 +1,13 @@
 <section class="light" id="portfolio">
     <h2>Portfolio</h2>
-    <div style="display: flex; flex-direction: row; padding-top: 3rem;">
+    <div class="portfolio-container">
     @if (projects is null)
     {
         <p><em>Loading...</em></p>
     }
     else
     {
-        <div style="max-width: 40%; align-self: center;">
+        <div class="portfolio-hero">
             @if (hero is not null)
             {
                 <img src="@(hero.Src)" style="height: 90%; width: 100%; object-fit: cover;" 

--- a/src/BlazorApp/wwwroot/css/app.css
+++ b/src/BlazorApp/wwwroot/css/app.css
@@ -53,6 +53,33 @@ h1 {
   margin: 0;
 }
 
+@media screen and (max-width: 300px) {
+  h1 {
+    font-weight: 300;
+    font-family: "Cormorant Garamond", serif;
+    font-size: 3rem;
+    margin: 0;
+  }
+}
+
+@media screen and (min-width: 301px) and (max-width: 360px) {
+  h1 {
+    font-weight: 300;
+    font-family: "Cormorant Garamond", serif;
+    font-size: 4rem;
+    margin: 0;
+  }
+}
+
+@media screen and (min-width: 361px) and (max-width: 420px) {
+  h1 {
+    font-weight: 300;
+    font-family: "Cormorant Garamond", serif;
+    font-size: 5rem;
+    margin: 0;
+  }
+}
+
 h2 {
   font-weight: 400;
   font-size: 2rem;
@@ -102,11 +129,44 @@ a:hover {
   color: #4e567e;
 }
 
+.portfolio-container {
+  display: flex;
+  flex-direction: row;
+  padding-top: 3rem;
+}
+
+@media screen and (max-width: 420px) {
+  .portfolio-container {
+    flex-direction: column;
+  }
+}
+
+.portfolio-hero {
+  max-width: 40%;
+  align-self: center;
+}
+
+@media screen and (max-width: 420px) {
+  .portfolio-hero {
+    max-width: 100%;
+    align-self: center;
+  }
+}
+
 .container {
   margin: 20px auto;
   display: grid;
   grid-template-columns: 330px 300px;
   grid-gap: 20px;
+}
+
+@media screen and (max-width: 420px) {
+  .container {
+    margin: 20px auto;
+    display: inline;
+    grid-template-columns: 330px 300px;
+    grid-gap: 20px;
+  }
 }
 
 .container .box {


### PR DESCRIPTION
This PR is to:

* Add media control for small screens less than 420px wide to display the main banner properly
* Add media control for small screens less than 420px wide to display the portfolio grid properly

@alfredodeza Would you please be able to take a look at this?