### PR TITLE
fix: add missing dot, update icon 'alt' texts

### DIFF
--- a/src/BlazorApp/Shared/Footer.razor
+++ b/src/BlazorApp/Shared/Footer.razor
@@ -35,25 +35,25 @@
             @if (string.IsNullOrWhiteSpace(property.LinkedIn) is false)
             {
                 <a href="https://linkedin.com/in/@(property.LinkedIn)" target="_blank" rel="noopener noreferrer">
-                    <img src="@icons.LinkedIn" alt="Dev.to" class="social-icon" />
+                    <img src="@icons.LinkedIn" alt="LinkedIn" class="social-icon" />
                 </a>
             }
             @if (string.IsNullOrWhiteSpace(property.Medium) is false)
             {
                 <a href="https://medium.com/@@@(property.Medium)" target="_blank" rel="noopener noreferrer">
-                    <img src="@icons.Medium" alt="Dev.to" class="social-icon" />
+                    <img src="@icons.Medium" alt="Medium" class="social-icon" />
                 </a>
             }
             @if (string.IsNullOrWhiteSpace(property.Twitter) is false)
             {
                 <a href="https://twitter.com/@(property.Twitter)" target="_blank" rel="noopener noreferrer">
-                    <img src="@icons.Twitter" alt="Dev.to" class="social-icon" />
+                    <img src="@icons.Twitter" alt="Twitter" class="social-icon" />
                 </a>
             }
             @if (string.IsNullOrWhiteSpace(property.YouTube) is false)
             {
                 <a href="https://youtube.com/@(property.YouTube)" target="_blank" rel="noopener noreferrer">
-                    <img src="@icons.YouTube" alt="Dev.to" class="social-icon" />
+                    <img src="@icons.YouTube" alt="YouTube" class="social-icon" />
                 </a>
             }
         </div>

--- a/src/BlazorApp/wwwroot/sample-data/socialicons.json
+++ b/src/BlazorApp/wwwroot/sample-data/socialicons.json
@@ -4,7 +4,7 @@
   "gitHub": "images/socials/github.svg",
   "instagram": "images/socials/instagram.svg",
   "linkedIn": "images/socials/linkedin.svg",
-  "medium": "images/socials/mediumsvg",
+  "medium": "images/socials/medium.svg",
   "twitter": "images/socials/twitter.svg",
   "youTube": "images/socials/youtube.svg"
 }


### PR DESCRIPTION
Just a little fixup PR:
- adds a missing dot in the path to `medium.svg` icon
- fixes copy-paste leftovers in `alt` texts of icons