### PR TITLE
Get down arrow to navigate to about section

### DIFF
--- a/src/BlazorApp/Components/Home.razor
+++ b/src/BlazorApp/Components/Home.razor
@@ -15,7 +15,9 @@
     }
     </div>
     <div style="position: absolute; bottom: 8rem; left: 50%;">
-        <img src="images/down-arrow.svg" style="height: 3rem; width: 3rem;" alt="scroll down" />
+        <a href="#about" target="_top">
+            <img src="images/down-arrow.svg" style="height: 3rem; width: 3rem;" alt="scroll down" />
+        </a>
     </div>
 </section>
 


### PR DESCRIPTION
Currently clicking on the down arrow does nothing. This at least moves the screen down to the about section.